### PR TITLE
Fix: /run-prompt not running models correctly

### DIFF
--- a/commands/fix-gh-issue.md
+++ b/commands/fix-gh-issue.md
@@ -252,7 +252,7 @@ Invoke run-prompt skill with generated prompt:
 
 ```
 Skill(
-  skill: "run-prompt",
+  skill: "founder-mode:run-prompt",
   args: "{prompt_file} --model {selected_model} {--worktree unless --no-worktree}"
 )
 ```
@@ -281,7 +281,7 @@ PROMPT_LIST=$(ls .founder-mode/prompts/gh-issues/gh-*.md | tr '\n' ',' | sed 's/
 
 ```
 Skill(
-  skill: "orchestrate",
+  skill: "founder-mode:orchestrate",
   args: "{prompt_list} --model {selected_model} {--worktree unless --no-worktree}"
 )
 ```


### PR DESCRIPTION
## Summary
Fixes #7

The root cause was that Skill invocations in `fix-gh-issue.md` used unqualified command names (`run-prompt`, `orchestrate`) instead of fully-qualified names (`founder-mode:run-prompt`, `founder-mode:orchestrate`). When a user had a personal command with the same name, the wrong command was invoked.

## Changes
- `commands/fix-gh-issue.md`: Changed `skill: "run-prompt"` to `skill: "founder-mode:run-prompt"`
- `commands/fix-gh-issue.md`: Changed `skill: "orchestrate"` to `skill: "founder-mode:orchestrate"`

## Test plan
- [ ] Run `/founder-mode:fix-gh-issue` with a personal `run-prompt` command present - should use founder-mode version
- [ ] Verify `claude-zai` model selection works correctly through the full flow