### PR TITLE
refactor: rename slash commands from /founder-mode to /fm

### DIFF
--- a/.planning/phases/01-foundation/1-RESEARCH.md
+++ b/.planning/phases/01-foundation/1-RESEARCH.md
@@ -164,7 +164,7 @@ allowed-tools:
 **When to use:** Any skill that spawns sub-agents
 **How it works:**
 ```
-1. User invokes skill (e.g., /founder-mode:run-prompt 123)
+1. User invokes skill (e.g., /fm:run-prompt 123)
 2. Skill calls executor.py with arguments
 3. Executor resolves:
    - Prompt file path and content

--- a/.planning/phases/02-prompt-workflow/02-01-PLAN.md
+++ b/.planning/phases/02-prompt-workflow/02-01-PLAN.md
@@ -73,7 +73,7 @@ Create a skill file that implements the prompt creation wizard:
 5. **After Save:**
    - Show prompt path
    - Offer: Run now, Edit first, Save for later
-   - If "Run now", invoke /founder-mode:run-prompt via Skill tool
+   - If "Run now", invoke /fm:run-prompt via Skill tool
 
 Adapt the patterns from daplug's create-prompt.md but simplify:
 - Remove cclimits/AI quota checking (out of scope for founder-mode)

--- a/.planning/phases/02-prompt-workflow/02-01-SUMMARY.md
+++ b/.planning/phases/02-prompt-workflow/02-01-SUMMARY.md
@@ -44,7 +44,7 @@ Implemented create-prompt wizard command with clarification flow, three XML temp
 
 2. **Template structure:** Used XML-based templates matching daplug's proven pattern but streamlined for founder-mode's simpler scope.
 
-3. **Skill tool in allowed-tools:** Added `Skill` tool to enable invoking `/founder-mode:run-prompt` directly from post-save actions.
+3. **Skill tool in allowed-tools:** Added `Skill` tool to enable invoking `/fm:run-prompt` directly from post-save actions.
 
 4. **Default to coding template:** When task type is ambiguous, default to coding since most prompts involve code changes.
 

--- a/.planning/phases/02-prompt-workflow/02-02-PLAN.md
+++ b/.planning/phases/02-prompt-workflow/02-02-PLAN.md
@@ -184,7 +184,7 @@ Background execution creates predictable COMPLETION.md with status, summary, and
 
 <verification>
 Before declaring plan complete:
-- [ ] Default `/founder-mode:run-prompt prompt.md` runs immediately without menus
+- [ ] Default `/fm:run-prompt prompt.md` runs immediately without menus
 - [ ] Background execution creates COMPLETION.md with structured status
 - [ ] User gets clear instructions for monitoring background tasks
 - [ ] Worktree + background combination documented and working

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,12 +77,12 @@ When implemented, this will auto-detect project type and run setup after worktre
 
 ## Available Commands
 
-### /founder-mode:run-prompt
+### /fm:run-prompt
 
 Execute a prompt with Claude or other AI models.
 
 ```
-/founder-mode:run-prompt <prompt-file> [--model claude|codex|gemini] [--background] [--worktree]
+/fm:run-prompt <prompt-file> [--model claude|codex|gemini] [--background] [--worktree]
 ```
 
 **Arguments:**
@@ -93,16 +93,16 @@ Execute a prompt with Claude or other AI models.
 
 **Examples:**
 ```
-/founder-mode:run-prompt prompts/001-setup.md
-/founder-mode:run-prompt prompts/001-setup.md --model codex --worktree
+/fm:run-prompt prompts/001-setup.md
+/fm:run-prompt prompts/001-setup.md --model codex --worktree
 ```
 
-### /founder-mode:orchestrate
+### /fm:orchestrate
 
 Execute multiple prompts with dependency management and parallel execution.
 
 ```
-/founder-mode:orchestrate <orchestrator-file|prompt-list> [--model ?|claude|codex|...] [--pending-only]
+/fm:orchestrate <orchestrator-file|prompt-list> [--model ?|claude|codex|...] [--pending-only]
 ```
 
 **Arguments:**
@@ -114,9 +114,9 @@ Execute multiple prompts with dependency management and parallel execution.
 
 **Examples:**
 ```
-/founder-mode:orchestrate prompts/phase-completion/000-orchestrator.md
-/founder-mode:orchestrate 003-01,003-02,003-03 --model codex
-/founder-mode:orchestrate prompts/000-orchestrator.md --pending-only --background
+/fm:orchestrate prompts/phase-completion/000-orchestrator.md
+/fm:orchestrate 003-01,003-02,003-03 --model codex
+/fm:orchestrate prompts/000-orchestrator.md --pending-only --background
 ```
 
 ## Deviation Handling

--- a/agents/plan-checker.md
+++ b/agents/plan-checker.md
@@ -1,6 +1,6 @@
 ---
 name: plan-checker
-description: Verifies plans will achieve phase goal before execution. Goal-backward analysis of plan quality. Spawned by /founder-mode:plan-phase orchestrator.
+description: Verifies plans will achieve phase goal before execution. Goal-backward analysis of plan quality. Spawned by /fm:plan-phase orchestrator.
 tools: Read, Bash, Glob, Grep
 ---
 
@@ -9,7 +9,7 @@ You are a plan checker. You verify that plans WILL achieve the phase goal, not j
 
 You are spawned by:
 
-- `/founder-mode:plan-phase` orchestrator (after plans are created)
+- `/fm:plan-phase` orchestrator (after plans are created)
 - Re-verification (after planner revises based on your feedback)
 
 Your job: Goal-backward verification of PLANS before execution. Start from what the phase SHOULD deliver, verify the plans address it.
@@ -523,7 +523,7 @@ When all checks pass:
 
 ### Ready for Execution
 
-Plans verified. Run `/founder-mode:execute-phase {phase}` to proceed.
+Plans verified. Run `/fm:execute-phase {phase}` to proceed.
 ```
 
 ## ISSUES FOUND

--- a/agents/verifier.md
+++ b/agents/verifier.md
@@ -531,7 +531,7 @@ score = (verified_truths / total_truths)
 
 <gap_output_format>
 
-When gaps are found, structure them for consumption by `/founder-mode:plan-phase --gaps`.
+When gaps are found, structure them for consumption by `/fm:plan-phase --gaps`.
 
 **Output structured gaps in YAML frontmatter:**
 
@@ -571,7 +571,7 @@ gaps:
 - `artifacts`: Which files have issues and what's wrong
 - `missing`: Specific things that need to be added/fixed
 
-The planner (`/founder-mode:plan-phase --gaps`) reads this gap analysis and creates appropriate plans.
+The planner (`/fm:plan-phase --gaps`) reads this gap analysis and creates appropriate plans.
 
 **Group related gaps by concern** when possible. If multiple truths fail because of the same root cause (e.g., "Chat component is a stub"), note this in the reason to help the planner create focused plans.
 
@@ -694,7 +694,7 @@ All must-haves verified. Phase goal achieved. Ready to proceed.
 2. **{Truth 2}** - {reason}
    - Missing: {what needs to be added}
 
-Structured gaps in VERIFICATION.md frontmatter for `/founder-mode:plan-phase --gaps`.
+Structured gaps in VERIFICATION.md frontmatter for `/fm:plan-phase --gaps`.
 
 {If human_needed:}
 
@@ -720,7 +720,7 @@ Automated checks passed. Awaiting human verification.
 
 **DO NOT skip key link verification.** This is where 80% of stubs hide. The pieces exist but aren't connected.
 
-**Structure gaps in YAML frontmatter.** The planner (`/founder-mode:plan-phase --gaps`) creates plans from your analysis.
+**Structure gaps in YAML frontmatter.** The planner (`/fm:plan-phase --gaps`) creates plans from your analysis.
 
 **DO flag for human verification when uncertain.** If you can't verify programmatically (visual, real-time, external service), say so explicitly.
 

--- a/commands/create-prompt.md
+++ b/commands/create-prompt.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:create-prompt
+name: fm:create-prompt
 description: Create optimized prompts with clarifying questions
 argument-hint: [task description] [--folder path]
 allowed-tools:
@@ -160,13 +160,13 @@ Choose (1-3):
 
 <post_save_actions>
 **Option 1 (Run now):**
-Invoke via Skill tool: `/founder-mode:run-prompt ./prompts/{filename}`
+Invoke via Skill tool: `/fm:run-prompt ./prompts/{filename}`
 
 **Option 2 (Edit first):**
-Display: "The prompt is saved at ./prompts/{filename}. Edit it with your preferred editor, then run with `/founder-mode:run-prompt {filename}`"
+Display: "The prompt is saved at ./prompts/{filename}. Edit it with your preferred editor, then run with `/fm:run-prompt {filename}`"
 
 **Option 3 (Save for later):**
-Display: "Prompt saved. Run later with `/founder-mode:run-prompt {filename}`"
+Display: "Prompt saved. Run later with `/fm:run-prompt {filename}`"
 </post_save_actions>
 
 ## Prompt Templates

--- a/commands/discuss-phase.md
+++ b/commands/discuss-phase.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:discuss-phase
+name: fm:discuss-phase
 description: Capture user vision and decisions before planning begins, preventing Claude from making assumptions
 argument-hint: [N] [--refresh]
 allowed-tools:
@@ -104,7 +104,7 @@ AskUserQuestion:
 If "Keep current context", exit with:
 ```
 Using existing context: {context_file}
-Run /founder-mode:plan-phase {N} to continue.
+Run /fm:plan-phase {N} to continue.
 ```
 
 If "Review and update", load existing decisions to present during gray area discussion.
@@ -590,7 +590,7 @@ Claude's discretion: {count} areas
 Deferred ideas: {count} items
 
 Next step:
-  /founder-mode:plan-phase {N}
+  /fm:plan-phase {N}
 ```
 </completion_message>
 
@@ -603,7 +603,7 @@ If .founder-mode/PROJECT.md doesn't exist:
 ```
 No project found.
 
-Run /founder-mode:new-project first to initialize.
+Run /fm:new-project first to initialize.
 ```
 </error_no_project>
 
@@ -612,7 +612,7 @@ If .founder-mode/ROADMAP.md doesn't exist:
 ```
 No roadmap found.
 
-Run /founder-mode:new-project to create roadmap.
+Run /fm:new-project to create roadmap.
 ```
 </error_no_roadmap>
 
@@ -624,7 +624,7 @@ Phase {N} not found in ROADMAP.md.
 Available phases:
 {list phases from ROADMAP.md}
 
-Use: /founder-mode:discuss-phase {valid_phase_number}
+Use: /fm:discuss-phase {valid_phase_number}
 ```
 </error_phase_not_found>
 
@@ -634,7 +634,7 @@ If phase is already marked complete:
 Phase {N} is already complete.
 
 To re-discuss for iteration:
-  /founder-mode:discuss-phase {N} --refresh
+  /fm:discuss-phase {N} --refresh
 ```
 </error_phase_complete>
 
@@ -644,17 +644,17 @@ To re-discuss for iteration:
 
 **Discuss current phase:**
 ```
-/founder-mode:discuss-phase
+/fm:discuss-phase
 ```
 
 **Discuss specific phase:**
 ```
-/founder-mode:discuss-phase 3
+/fm:discuss-phase 3
 ```
 
 **Re-discuss with existing context:**
 ```
-/founder-mode:discuss-phase 2 --refresh
+/fm:discuss-phase 2 --refresh
 ```
 
 ---

--- a/commands/execute-phase.md
+++ b/commands/execute-phase.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:execute-phase
+name: fm:execute-phase
 description: Execute all plans in a phase with wave-based parallelization
 argument-hint: "[N] [--gaps-only]"
 allowed-tools:
@@ -41,13 +41,13 @@ Check that required project files exist and phase is valid:
 ```bash
 # Check for project
 if [ ! -d ".founder-mode" ]; then
-    echo "No project found. Run /founder-mode:new-project first."
+    echo "No project found. Run /fm:new-project first."
     exit 1
 fi
 
 # Check for STATE.md
 if [ ! -f ".founder-mode/STATE.md" ]; then
-    echo "No state found. Run /founder-mode:new-project first."
+    echo "No state found. Run /fm:new-project first."
     exit 1
 fi
 
@@ -95,7 +95,7 @@ PLANS=$(ls ${PHASE_DIR}/*-PLAN.md 2>/dev/null)
 if [ -z "$PLANS" ]; then
     echo "No plans found in ${PHASE_DIR}"
     echo ""
-    echo "Run /founder-mode:plan-phase ${N} first."
+    echo "Run /fm:plan-phase ${N} first."
     exit 1
 fi
 
@@ -125,7 +125,7 @@ fi
 if [ ${#PENDING_PLANS[@]} -eq 0 ]; then
     echo ""
     echo "No incomplete plans. Phase may already be complete."
-    echo "Run /founder-mode:execute-phase ${N} --force to re-execute."
+    echo "Run /fm:execute-phase ${N} --force to re-execute."
     exit 0
 fi
 ```
@@ -464,7 +464,7 @@ What's Missing:
    - Artifacts: {files with issues}
    - Missing: {what needs to be added}
 
-Next step: /founder-mode:plan-phase {N} --gaps
+Next step: /fm:plan-phase {N} --gaps
 ```
 
 **If human_needed:**
@@ -584,11 +584,11 @@ Next Up
 
 Phase {N+1}: {Name} - {Goal from ROADMAP.md}
 
-/founder-mode:discuss-phase {N+1} - gather context and clarify approach
+/fm:discuss-phase {N+1} - gather context and clarify approach
 
 Also available:
-- /founder-mode:plan-phase {N+1} - skip discussion, plan directly
-- /founder-mode:verify-work {N} - manual acceptance testing before continuing
+- /fm:plan-phase {N+1} - skip discussion, plan directly
+- /fm:verify-work {N} - manual acceptance testing before continuing
 ```
 
 **Route B: Last phase complete (status: passed)**
@@ -607,11 +607,11 @@ Next Up
 
 Audit milestone - verify requirements, cross-phase integration, E2E flows
 
-/founder-mode:audit-milestone
+/fm:audit-milestone
 
 Also available:
-- /founder-mode:verify-work - manual acceptance testing
-- /founder-mode:complete-milestone - skip audit, archive directly
+- /fm:verify-work - manual acceptance testing
+- /fm:complete-milestone - skip audit, archive directly
 ```
 
 **Route C: Gaps found (status: gaps_found)**
@@ -635,19 +635,19 @@ Next Up
 
 Plan gap closure - create additional plans to complete the phase
 
-/founder-mode:plan-phase {N} --gaps
+/fm:plan-phase {N} --gaps
 
 Also available:
 - cat {PHASE_DIR}/{PHASE}-VERIFICATION.md - see full report
-- /founder-mode:verify-work {N} - manual testing before planning
+- /fm:verify-work {N} - manual testing before planning
 ```
 
 **Gap closure loop:**
 
-After user runs `/founder-mode:plan-phase {N} --gaps`:
+After user runs `/fm:plan-phase {N} --gaps`:
 1. Planner reads VERIFICATION.md gaps
 2. Creates additional plans (04, 05, etc.) to close gaps
-3. User runs `/founder-mode:execute-phase {N}` again
+3. User runs `/fm:execute-phase {N}` again
 4. Execute-phase runs only incomplete plans (04, 05...)
 5. Verifier runs again
 6. Loop until passed
@@ -925,7 +925,7 @@ If .founder-mode/ doesn't exist:
 ```
 No project found.
 
-Run /founder-mode:new-project first to initialize.
+Run /fm:new-project first to initialize.
 ```
 </error_no_project>
 
@@ -935,7 +935,7 @@ If no PLAN.md files in phase directory:
 ```
 No plans found for Phase {N}.
 
-Run /founder-mode:plan-phase {N} first to create plans.
+Run /fm:plan-phase {N} first to create plans.
 ```
 </error_no_plans>
 
@@ -948,7 +948,7 @@ Phase {N} not found.
 Available phases:
 {list phases from .founder-mode/plans/}
 
-Use: /founder-mode:execute-phase {valid_phase_number}
+Use: /fm:execute-phase {valid_phase_number}
 ```
 </error_phase_not_found>
 
@@ -967,7 +967,7 @@ Options:
 2. Skip and continue with wave
 3. Abort phase execution
 
-Retry with: /founder-mode:execute-phase {N}
+Retry with: /fm:execute-phase {N}
 (Will only run incomplete plans)
 ```
 </error_executor_failed>
@@ -978,17 +978,17 @@ Retry with: /founder-mode:execute-phase {N}
 
 **Execute current phase:**
 ```
-/founder-mode:execute-phase
+/fm:execute-phase
 ```
 
 **Execute specific phase:**
 ```
-/founder-mode:execute-phase 3
+/fm:execute-phase 3
 ```
 
 **Execute gap closure plans only:**
 ```
-/founder-mode:execute-phase 2 --gaps-only
+/fm:execute-phase 2 --gaps-only
 ```
 
 ---

--- a/commands/fix-gh-issue.md
+++ b/commands/fix-gh-issue.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:fix-gh-issue
+name: fm:fix-gh-issue
 description: Fix a GitHub issue end-to-end from issue to PR
 argument-hint: "<issue-number> [--no-worktree] [--no-pr] [--draft] [--model ?|claude|codex|...]"
 allowed-tools:
@@ -510,37 +510,37 @@ Manual creation:
 
 **Fix single issue:**
 ```
-/founder-mode:fix-gh-issue 123
+/fm:fix-gh-issue 123
 ```
 → Asks for model, generates prompt, runs via run-prompt, creates PR
 
 **Fix multiple issues (always separate worktrees):**
 ```
-/founder-mode:fix-gh-issue 123 456 789
+/fm:fix-gh-issue 123 456 789
 ```
 → Creates 3 separate worktrees, generates 3 prompts, runs via orchestrate, creates 3 separate PRs
 
 **Fix dependent issues:**
 ```
-/founder-mode:fix-gh-issue 100 101  # where 101 depends on 100
+/fm:fix-gh-issue 100 101  # where 101 depends on 100
 ```
 → Creates separate worktrees, works in parallel, merges 100 into 101's worktree when ready, creates 2 PRs
 
 **Fix with specific model:**
 ```
-/founder-mode:fix-gh-issue 123 --model codex
+/fm:fix-gh-issue 123 --model codex
 ```
 → Skips model selection, uses codex
 
 **Fix without worktree:**
 ```
-/founder-mode:fix-gh-issue 123 --no-worktree
+/fm:fix-gh-issue 123 --no-worktree
 ```
 → Works in current directory instead of isolated worktree
 
 **Fix as draft PR:**
 ```
-/founder-mode:fix-gh-issue 123 --draft
+/fm:fix-gh-issue 123 --draft
 ```
 → Creates draft PR instead of ready-for-review
 

--- a/commands/list-github-issues.md
+++ b/commands/list-github-issues.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:list-github-issues
+name: fm:list-github-issues
 description: List GitHub issues with filtering
 argument-hint: "[--assignee @me] [--label bug] [--state open]"
 allowed-tools:
@@ -82,8 +82,8 @@ GitHub Issues ({count} {state}, assigned to {assignee})
      Created: 3 days ago
 
 Commands:
-  /founder-mode:fix-gh-issue 123         Fix issue #123
-  /founder-mode:fix-gh-issue 123 456 789 Fix multiple issues
+  /fm:fix-gh-issue 123         Fix issue #123
+  /fm:fix-gh-issue 123 456 789 Fix multiple issues
 ```
 
 ### Step 6: Handle Errors

--- a/commands/list-jira-tickets.md
+++ b/commands/list-jira-tickets.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:list-jira-tickets
+name: fm:list-jira-tickets
 description: List Jira tickets with filtering
 argument-hint: "[--project PROJ] [--assignee me] [--status 'To Do']"
 allowed-tools:
@@ -49,7 +49,7 @@ elif [ -f .founder-mode/jira.json ]; then
   }
 else
   echo "ERROR: Jira not configured"
-  echo "See: /founder-mode:help jira-setup"
+  echo "See: /fm:help jira-setup"
   exit 1
 fi
 ```
@@ -117,8 +117,8 @@ PROJ-789 [Task] Update documentation
          Sprint: Sprint 24
 
 Commands:
-  /founder-mode:fix-jira-ticket PROJ-123
-  /founder-mode:fix-issues PROJ-123 PROJ-456  (parallel)
+  /fm:fix-jira-ticket PROJ-123
+  /fm:fix-issues PROJ-123 PROJ-456  (parallel)
 ```
 
 ### Step 6: Handle Errors

--- a/commands/new-project.md
+++ b/commands/new-project.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:new-project
+name: fm:new-project
 description: Initialize a new project with deep context gathering and planning artifacts
 argument-hint: [--skip-research] [--brownfield]
 allowed-tools:
@@ -984,10 +984,10 @@ Summary:
 - Planning depth: {depth}
 
 Next step:
-  /founder-mode:plan-phase 1
+  /fm:plan-phase 1
 
 Or check progress:
-  /founder-mode:progress
+  /fm:progress
 ```
 </completion_message>
 
@@ -1014,7 +1014,7 @@ mv .founder-mode .founder-mode.bak.{timestamp}
 
 If "Resume":
 ```
-Use /founder-mode:progress to check current state.
+Use /fm:progress to check current state.
 ```
 </error_directory_exists>
 
@@ -1055,15 +1055,15 @@ Use AskUserQuestion to let user decide.
 
 **Initialize new project:**
 ```
-/founder-mode:new-project
+/fm:new-project
 ```
 
 **Skip research (known domain):**
 ```
-/founder-mode:new-project --skip-research
+/fm:new-project --skip-research
 ```
 
 **Force brownfield mode:**
 ```
-/founder-mode:new-project --brownfield
+/fm:new-project --brownfield
 ```

--- a/commands/orchestrate.md
+++ b/commands/orchestrate.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:orchestrate
+name: fm:orchestrate
 description: Execute multiple prompts with dependency management and parallel execution
 argument-hint: <orchestrator-file|prompt-list> [--model ?|claude|codex|...] [--pending-only]
 allowed-tools:
@@ -183,7 +183,7 @@ Working directory: {cwd}
 Model: {selected_model}
 
 If non-Claude model, call:
-/founder-mode:run-prompt {prompt_path} --model {model} {--background} {--worktree}
+/fm:run-prompt {prompt_path} --model {model} {--background} {--worktree}
 
 Execute completely. Write results to .founder-mode/logs/{prompt_id}-result.json:
 {
@@ -304,22 +304,22 @@ Write updated file.
 
 **Run orchestrator file:**
 ```
-/founder-mode:orchestrate prompts/phase-completion/000-orchestrator.md
+/fm:orchestrate prompts/phase-completion/000-orchestrator.md
 ```
 
 **Run specific prompts (no deps, all parallel):**
 ```
-/founder-mode:orchestrate 003-01,003-02,003-03 --model codex
+/fm:orchestrate 003-01,003-02,003-03 --model codex
 ```
 
 **Run pending prompts only:**
 ```
-/founder-mode:orchestrate prompts/phase-completion/000-orchestrator.md --pending-only
+/fm:orchestrate prompts/phase-completion/000-orchestrator.md --pending-only
 ```
 
 **Run in background with worktrees:**
 ```
-/founder-mode:orchestrate 003-01,003-02 --model codex --background --worktree
+/fm:orchestrate 003-01,003-02 --model codex --background --worktree
 ```
 
 ## Error Handling

--- a/commands/plan-phase.md
+++ b/commands/plan-phase.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:plan-phase
+name: fm:plan-phase
 description: Create executable PLAN.md files with pre-execution validation loop
 argument-hint: [N] [--gaps] [--skip-validation]
 allowed-tools:
@@ -44,19 +44,19 @@ Check that required project files exist:
 ```bash
 # Check for PROJECT.md
 if [ ! -f ".founder-mode/PROJECT.md" ]; then
-    echo "No project found. Run /founder-mode:new-project first."
+    echo "No project found. Run /fm:new-project first."
     exit 1
 fi
 
 # Check for ROADMAP.md
 if [ ! -f ".founder-mode/ROADMAP.md" ]; then
-    echo "No roadmap found. Run /founder-mode:new-project first."
+    echo "No roadmap found. Run /fm:new-project first."
     exit 1
 fi
 
 # Check for STATE.md
 if [ ! -f ".founder-mode/STATE.md" ]; then
-    echo "No state found. Run /founder-mode:new-project first."
+    echo "No state found. Run /fm:new-project first."
     exit 1
 fi
 
@@ -131,7 +131,7 @@ if grep -q "Phase $N:.*Complete" .founder-mode/ROADMAP.md; then
     echo "Phase $N is already complete."
     echo ""
     echo "To re-plan:"
-    echo "  /founder-mode:plan-phase $N --force"
+    echo "  /fm:plan-phase $N --force"
     exit 1
 fi
 ```
@@ -165,7 +165,7 @@ If research is "Likely" and no RESEARCH.md exists:
 AskUserQuestion:
   question: "This phase may need research. How to proceed?"
   options:
-    - "Run research first (/founder-mode:research-phase)"
+    - "Run research first (/fm:research-phase)"
     - "Skip research and plan directly"
     - "Cancel and do manual research"
 ```
@@ -174,10 +174,10 @@ If research selected, report:
 
 ```
 Research recommended. Run:
-  /founder-mode:research-phase {N}
+  /fm:research-phase {N}
 
 Then return to:
-  /founder-mode:plan-phase {N}
+  /fm:plan-phase {N}
 ```
 
 Exit and let user run research command.
@@ -665,7 +665,7 @@ Checkpoints:
 {/if}
 
 Next step:
-  /founder-mode:execute-phase {N}
+  /fm:execute-phase {N}
 
 Or review plans:
   cat .founder-mode/plans/phase-{N}/*-PLAN.md
@@ -766,7 +766,7 @@ If .founder-mode/PROJECT.md doesn't exist:
 ```
 No project found.
 
-Run /founder-mode:new-project first to initialize.
+Run /fm:new-project first to initialize.
 ```
 </error_no_project>
 
@@ -776,7 +776,7 @@ If .founder-mode/ROADMAP.md doesn't exist:
 ```
 No roadmap found.
 
-Run /founder-mode:new-project to create roadmap.
+Run /fm:new-project to create roadmap.
 ```
 </error_no_roadmap>
 
@@ -789,7 +789,7 @@ Phase {N} not found in ROADMAP.md.
 Available phases:
 {list phases from ROADMAP.md}
 
-Use: /founder-mode:plan-phase {valid_phase_number}
+Use: /fm:plan-phase {valid_phase_number}
 ```
 </error_phase_not_found>
 
@@ -800,7 +800,7 @@ If phase is already marked complete:
 Phase {N} is already complete.
 
 To re-plan (will archive existing plans):
-  /founder-mode:plan-phase {N} --force
+  /fm:plan-phase {N} --force
 ```
 </error_phase_complete>
 
@@ -813,9 +813,9 @@ Validation incomplete.
 {blocker_count} blockers remain after 3 iterations.
 
 Options:
-1. /founder-mode:plan-phase {N} --skip-validation
+1. /fm:plan-phase {N} --skip-validation
 2. Manually edit plans in .founder-mode/plans/phase-{N}/
-3. /founder-mode:discuss-phase {N} to gather more context
+3. /fm:discuss-phase {N} to gather more context
 ```
 </error_validation_failed>
 
@@ -825,27 +825,27 @@ Options:
 
 **Plan current phase:**
 ```
-/founder-mode:plan-phase
+/fm:plan-phase
 ```
 
 **Plan specific phase:**
 ```
-/founder-mode:plan-phase 3
+/fm:plan-phase 3
 ```
 
 **Plan inserted phase:**
 ```
-/founder-mode:plan-phase 2.1
+/fm:plan-phase 2.1
 ```
 
 **Gap closure mode:**
 ```
-/founder-mode:plan-phase 2 --gaps
+/fm:plan-phase 2 --gaps
 ```
 
 **Skip validation (force):**
 ```
-/founder-mode:plan-phase 1 --skip-validation
+/fm:plan-phase 1 --skip-validation
 ```
 
 ---

--- a/commands/run-prompt.md
+++ b/commands/run-prompt.md
@@ -1,5 +1,5 @@
 ---
-name: founder-mode:run-prompt
+name: fm:run-prompt
 description: Execute a prompt with Claude or other AI models
 argument-hint: <prompt-file> [--model ?|claude|codex|gemini|...] [--background] [--worktree] [--loop] [--two-stage]
 allowed-tools:
@@ -52,7 +52,7 @@ Use for complex prompts where both correctness and quality matter.
 
 Example:
 ```bash
-/founder-mode:run-prompt my-feature --model codex --loop --two-stage
+/fm:run-prompt my-feature --model codex --loop --two-stage
 ```
 
 Result JSON includes:
@@ -81,12 +81,12 @@ When no `--model` is specified (or `--model ?` is used):
 5. Show result
 
 ```
-/founder-mode:run-prompt prompts/fix-bug.md
+/fm:run-prompt prompts/fix-bug.md
 ```
 
 To skip the model selection prompt, specify a model explicitly:
 ```
-/founder-mode:run-prompt prompts/fix-bug.md --model claude
+/fm:run-prompt prompts/fix-bug.md --model claude
 ```
 
 ## Execution Flow
@@ -548,20 +548,20 @@ Other errors:
 
 **Run with Claude (default)**:
 ```
-/founder-mode:run-prompt prompts/001-setup.md
+/fm:run-prompt prompts/001-setup.md
 ```
 
 **Run with Codex**:
 ```
-/founder-mode:run-prompt prompts/001-setup.md --model codex
+/fm:run-prompt prompts/001-setup.md --model codex
 ```
 
 **Run in background with worktree**:
 ```
-/founder-mode:run-prompt prompts/001-setup.md --model codex --background --worktree
+/fm:run-prompt prompts/001-setup.md --model codex --background --worktree
 ```
 
 **Run with custom working directory**:
 ```
-/founder-mode:run-prompt prompts/001-setup.md --cwd /path/to/project
+/fm:run-prompt prompts/001-setup.md --cwd /path/to/project
 ```

--- a/prompts/003-generate-phase-prompts.md
+++ b/prompts/003-generate-phase-prompts.md
@@ -135,10 +135,10 @@ This prompt:
 
 `prompts/phase-completion/003-02-new-project.md`
 
-**Purpose:** Implement the unified `/founder-mode:new-project` command that initializes a project from scratch with deep context gathering.
+**Purpose:** Implement the unified `/fm:new-project` command that initializes a project from scratch with deep context gathering.
 
 **User Flow:**
-1. User runs `/founder-mode:new-project`
+1. User runs `/fm:new-project`
 2. Command asks 4-6 essential questions (vision, core priority, boundaries, constraints)
 3. Command offers research path (recommended) or fast path (skip research)
 4. If research: spawn parallel research agents to investigate stack, features, architecture, pitfalls
@@ -190,7 +190,7 @@ This prompt:
 
 `prompts/phase-completion/003-03-discuss-phase.md`
 
-**Purpose:** Implement `/founder-mode:discuss-phase [N]` command that captures user vision and decisions before planning begins.
+**Purpose:** Implement `/fm:discuss-phase [N]` command that captures user vision and decisions before planning begins.
 
 **Why This Exists:**
 - Prevents Claude from making assumptions about UI, UX, behavior
@@ -259,7 +259,7 @@ Ideas mentioned but out of scope for this phase.
 
 `prompts/phase-completion/003-04-plan-phase.md`
 
-**Purpose:** Implement `/founder-mode:plan-phase [N]` command with pre-execution validation loop.
+**Purpose:** Implement `/fm:plan-phase [N]` command with pre-execution validation loop.
 
 **Planning Flow:**
 1. Load phase context (ROADMAP goal, REQUIREMENTS for this phase, CONTEXT.md from discuss-phase)
@@ -298,7 +298,7 @@ must_haves:
 # Plan 03-01: Project Initialization Command
 
 ## Objective
-Create the /founder-mode:new-project command that initializes projects.
+Create the /fm:new-project command that initializes projects.
 
 ## Requirements Addressed
 - REQ-007: Greenfield project initialization
@@ -366,7 +366,7 @@ If phase involves unfamiliar domain (3D, audio, ML, payments, etc.):
 
 `prompts/phase-completion/003-05-execute-phase.md`
 
-**Purpose:** Implement `/founder-mode:execute-phase [N]` command with wave-based parallel execution and goal-backward verification.
+**Purpose:** Implement `/fm:execute-phase [N]` command with wave-based parallel execution and goal-backward verification.
 
 **Execution Flow:**
 1. Load all PLAN.md files for phase N
@@ -468,7 +468,7 @@ commits:
 # Plan 03-01 Summary
 
 ## What Was Built
-- /founder-mode:new-project command with questioning flow
+- /fm:new-project command with questioning flow
 - State management utilities (createProject, updateState, addRequirement)
 
 ## Files Changed
@@ -609,8 +609,8 @@ Create `references/verification-patterns.md` documenting how to verify different
 
 **Integration with Commands:**
 
-- `/founder-mode:plan-phase` spawns plan-checker after creating plans
-- `/founder-mode:execute-phase` spawns verifier after execution completes
+- `/fm:plan-phase` spawns plan-checker after creating plans
+- `/fm:execute-phase` spawns verifier after execution completes
 - Both agents return structured output for orchestrator to process
 - Orchestrator presents results to user and handles fix flows
 
@@ -620,7 +620,7 @@ Create `references/verification-patterns.md` documenting how to verify different
 
 `prompts/phase-completion/004-01-github-integration.md`
 
-**Purpose:** Implement GitHub issue fetching and the `/founder-mode:list-github-issues` command.
+**Purpose:** Implement GitHub issue fetching and the `/fm:list-github-issues` command.
 
 **Why This Matters:**
 - Pull work items directly from GitHub instead of manual copy-paste
@@ -644,7 +644,7 @@ gh issue view 123 --json title,body,labels,assignees,milestone
 gh issue list --json number,title,body,labels,state
 ```
 
-**Command: /founder-mode:list-github-issues**
+**Command: /fm:list-github-issues**
 
 ```markdown
 # List GitHub Issues
@@ -675,8 +675,8 @@ GitHub Issues (5 open, assigned to @me)
      Created: 3 days ago
 
 Commands:
-  /founder-mode:fix-gh-issue 123    Fix issue #123
-  /founder-mode:fix-gh-issue 123 456 789    Fix multiple issues
+  /fm:fix-gh-issue 123    Fix issue #123
+  /fm:fix-gh-issue 123 456 789    Fix multiple issues
 ```
 
 **Issue Normalization:**
@@ -712,7 +712,7 @@ interface NormalizedIssue {
 
 `prompts/phase-completion/004-02-jira-integration.md`
 
-**Purpose:** Implement Jira ticket fetching and the `/founder-mode:list-jira-tickets` command.
+**Purpose:** Implement Jira ticket fetching and the `/fm:list-jira-tickets` command.
 
 **Jira API Options:**
 
@@ -748,7 +748,7 @@ Jira requires API tokens. Configuration options:
 }
 ```
 
-**Command: /founder-mode:list-jira-tickets**
+**Command: /fm:list-jira-tickets**
 
 ```markdown
 # List Jira Tickets
@@ -773,7 +773,7 @@ PROJ-456 [Story] Add dark mode support
          Sprint: Sprint 23
 
 Commands:
-  /founder-mode:fix-jira-ticket PROJ-123
+  /fm:fix-jira-ticket PROJ-123
 ```
 
 **Issue Normalization:**
@@ -813,12 +813,12 @@ interface NormalizedIssue {
 
 `prompts/phase-completion/004-03-fix-gh-issue.md`
 
-**Purpose:** Implement the end-to-end `/founder-mode:fix-gh-issue` workflow that goes from issue to PR.
+**Purpose:** Implement the end-to-end `/fm:fix-gh-issue` workflow that goes from issue to PR.
 
 **Complete Workflow:**
 
 ```
-/founder-mode:fix-gh-issue 123
+/fm:fix-gh-issue 123
        ↓
 1. Fetch issue details from GitHub
        ↓
@@ -839,7 +839,7 @@ interface NormalizedIssue {
 9. Output PR URL
 ```
 
-**Command: /founder-mode:fix-gh-issue**
+**Command: /fm:fix-gh-issue**
 
 ```markdown
 # Fix GitHub Issue
@@ -991,7 +991,7 @@ Verification:
 **User Story:**
 "I have 5 bugs assigned to me. I want to say 'fix these' and have founder-mode work on all of them in parallel, showing me progress, and delivering 5 PRs."
 
-**Command: /founder-mode:fix-issues**
+**Command: /fm:fix-issues**
 
 ```markdown
 # Fix Multiple Issues
@@ -1125,7 +1125,7 @@ Current: Waiting to start
 Progress: 0/4 complete
 ```
 
-**Command: /founder-mode:run-sprint**
+**Command: /fm:run-sprint**
 
 ```markdown
 # Run Sprint
@@ -1142,13 +1142,13 @@ Progress: 0/4 complete
 ### Step 1: Build Queue
 ```bash
 # From explicit list
-/founder-mode:run-sprint --issues 123,456,789
+/fm:run-sprint --issues 123,456,789
 
 # From GitHub assigned issues
-/founder-mode:run-sprint --from-github --assignee @me
+/fm:run-sprint --from-github --assignee @me
 
 # From Jira sprint
-/founder-mode:run-sprint --from-jira --sprint "Sprint 23"
+/fm:run-sprint --from-jira --sprint "Sprint 23"
 ```
 
 ### Step 2: Present Sprint Plan
@@ -1257,15 +1257,15 @@ queue:
 
 Resume with:
 ```
-/founder-mode:run-sprint --resume
+/fm:run-sprint --resume
 ```
 
 **Issue Queue Management:**
 Allow mid-sprint queue modifications:
 ```
-/founder-mode:sprint-add 999    # Add issue to queue
-/founder-mode:sprint-remove 456 # Remove from queue
-/founder-mode:sprint-priority 789 1  # Move #789 to position 1
+/fm:sprint-add 999    # Add issue to queue
+/fm:sprint-remove 456 # Remove from queue
+/fm:sprint-priority 789 1  # Move #789 to position 1
 ```
 
 **Files Created:**

--- a/prompts/005-fix-opencode-log-integration.md
+++ b/prompts/005-fix-opencode-log-integration.md
@@ -144,15 +144,15 @@ Run these tests:
 
 ```bash
 # Test OpenCode foreground - check log has content
-/founder-mode:run-prompt test-prompt.md --model opencode
+/fm:run-prompt test-prompt.md --model opencode
 cat .founder-mode/logs/*.log | head -50
 
 # Test OpenCode background - verify log monitoring works
-/founder-mode:run-prompt test-prompt.md --model opencode --background
+/fm:run-prompt test-prompt.md --model opencode --background
 tail -f .founder-mode/logs/*.log
 
 # Test other models still work
-/founder-mode:run-prompt test-prompt.md --model codex
+/fm:run-prompt test-prompt.md --model codex
 ```
 
 Success criteria:

--- a/prompts/phase-completion/000-orchestrator.md
+++ b/prompts/phase-completion/000-orchestrator.md
@@ -137,7 +137,7 @@ commands/run-prompt.md    - Existing command pattern
 
 - [ ] All 12 prompt files executed successfully
 - [ ] Each prompt's verification steps pass
-- [ ] All commands are callable via /founder-mode:{command}
+- [ ] All commands are callable via /fm:{command}
 - [ ] State management utilities work correctly
 - [ ] Verification agents can be spawned
 - [ ] Integration tests pass (if applicable)

--- a/prompts/phase-completion/003-01-state-management.md
+++ b/prompts/phase-completion/003-01-state-management.md
@@ -321,7 +321,7 @@ Create `references/state-utilities.md` documenting utility patterns:
 To load project state:
 
 1. Check for .founder-mode/ directory
-2. If missing, error: "Project not initialized. Run /founder-mode:new-project"
+2. If missing, error: "Project not initialized. Run /fm:new-project"
 3. Read STATE.md, parse current position
 4. Read config.json for preferences
 

--- a/prompts/phase-completion/003-02-new-project.md
+++ b/prompts/phase-completion/003-02-new-project.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement the unified `/founder-mode:new-project` command that initializes a project from scratch with deep context gathering. This is the entry point for all new founder-mode projects.
+Implement the unified `/fm:new-project` command that initializes a project from scratch with deep context gathering. This is the entry point for all new founder-mode projects.
 
 ## Prerequisites
 
@@ -262,7 +262,7 @@ PROJECT INITIALIZED
 
 {N} phases | {X} requirements | Ready to build
 
-Next: /founder-mode:discuss-phase 1
+Next: /fm:discuss-phase 1
 ```
 
 ## Success Criteria
@@ -296,7 +296,7 @@ Check that command file has:
 
 ### Step 3: Test Command Registration
 
-The command should be accessible via `/founder-mode:new-project` when founder-mode plugin is loaded.
+The command should be accessible via `/fm:new-project` when founder-mode plugin is loaded.
 
 ## Verification
 

--- a/prompts/phase-completion/003-03-discuss-phase.md
+++ b/prompts/phase-completion/003-03-discuss-phase.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement `/founder-mode:discuss-phase [N]` command that captures user vision and decisions before planning begins. This prevents Claude from making assumptions about implementation details.
+Implement `/fm:discuss-phase [N]` command that captures user vision and decisions before planning begins. This prevents Claude from making assumptions about implementation details.
 
 ## Prerequisites
 
@@ -51,7 +51,7 @@ Parse from $ARGUMENTS:
 
 ```bash
 # Check project exists
-[ -d .founder-mode ] || { echo "ERROR: No project. Run /founder-mode:new-project"; exit 1; }
+[ -d .founder-mode ] || { echo "ERROR: No project. Run /fm:new-project"; exit 1; }
 
 # Normalize phase number
 PHASE=$(printf "%02d" $PHASE_ARG)
@@ -206,10 +206,10 @@ PHASE {N} CONTEXT CAPTURED
 {Z} deferred ideas noted
 
 Downstream consumers:
-- /founder-mode:plan-phase reads this for planning
+- /fm:plan-phase reads this for planning
 - Research agent (if used) focuses on undecided areas
 
-Next: /founder-mode:plan-phase {N}
+Next: /fm:plan-phase {N}
 ```
 
 ## Downstream Consumers

--- a/prompts/phase-completion/003-04-plan-phase.md
+++ b/prompts/phase-completion/003-04-plan-phase.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement `/founder-mode:plan-phase [N]` command with pre-execution validation loop. Creates executable PLAN.md files that Claude can implement without interpretation.
+Implement `/fm:plan-phase [N]` command with pre-execution validation loop. Creates executable PLAN.md files that Claude can implement without interpretation.
 
 ## Prerequisites
 
@@ -284,7 +284,7 @@ PHASE {N} PLANNED
 Research: {Completed | Used existing | Skipped}
 Verification: {Passed | Passed with override}
 
-Next: /founder-mode:execute-phase {N}
+Next: /fm:execute-phase {N}
 ```
 
 ## Gap Closure Mode (--gaps)

--- a/prompts/phase-completion/003-05-execute-phase.md
+++ b/prompts/phase-completion/003-05-execute-phase.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement `/founder-mode:execute-phase [N]` command with wave-based parallel execution and goal-backward verification.
+Implement `/fm:execute-phase [N]` command with wave-based parallel execution and goal-backward verification.
 
 ## Prerequisites
 
@@ -219,7 +219,7 @@ Task(
 |--------|--------|
 | passed | Continue to step 8 |
 | human_needed | Present items, get approval |
-| gaps_found | Present gaps, offer `/founder-mode:plan-phase {N} --gaps` |
+| gaps_found | Present gaps, offer `/fm:plan-phase {N} --gaps` |
 
 ### Step 8: Update State
 
@@ -256,7 +256,7 @@ PHASE {N} COMPLETE
 {X} plans executed
 Goal verified ✓
 
-Next: /founder-mode:discuss-phase {N+1}
+Next: /fm:discuss-phase {N+1}
 ```
 
 **If last phase:**
@@ -266,7 +266,7 @@ MILESTONE COMPLETE
 All phases executed
 Ready for review
 
-Next: /founder-mode:verify-work (manual testing)
+Next: /fm:verify-work (manual testing)
 ```
 
 **If gaps found:**
@@ -278,7 +278,7 @@ Score: {X}/{Y} must-haves verified
 What's Missing:
 {Gap summaries from VERIFICATION.md}
 
-Next: /founder-mode:plan-phase {N} --gaps
+Next: /fm:plan-phase {N} --gaps
 ```
 
 ## Checkpoint Handling

--- a/prompts/phase-completion/003-06-verification-agents.md
+++ b/prompts/phase-completion/003-06-verification-agents.md
@@ -399,7 +399,7 @@ gaps:  # Only if gaps_found
 1. **{Truth}** - {reason}
    - Missing: {what to add}
 
-Structured gaps in VERIFICATION.md for /founder-mode:plan-phase --gaps
+Structured gaps in VERIFICATION.md for /fm:plan-phase --gaps
 ```
 
 ## Stub Detection Patterns

--- a/prompts/phase-completion/004-01-github-integration.md
+++ b/prompts/phase-completion/004-01-github-integration.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement GitHub issue fetching and the `/founder-mode:list-github-issues` command. This is the foundation for the /fix-gh-issue workflow.
+Implement GitHub issue fetching and the `/fm:list-github-issues` command. This is the foundation for the /fix-gh-issue workflow.
 
 ## Prerequisites
 
@@ -169,8 +169,8 @@ GitHub Issues ({count} {state}, assigned to {assignee})
      Created: 3 days ago
 
 Commands:
-  /founder-mode:fix-gh-issue 123         Fix issue #123
-  /founder-mode:fix-gh-issue 123 456 789 Fix multiple issues
+  /fm:fix-gh-issue 123         Fix issue #123
+  /fm:fix-gh-issue 123 456 789 Fix multiple issues
 ```
 
 ### Step 6: Handle Errors

--- a/prompts/phase-completion/004-02-jira-integration.md
+++ b/prompts/phase-completion/004-02-jira-integration.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement Jira ticket fetching and the `/founder-mode:list-jira-tickets` command.
+Implement Jira ticket fetching and the `/fm:list-jira-tickets` command.
 
 ## Prerequisites
 
@@ -216,7 +216,7 @@ elif [ -f .founder-mode/jira.json ]; then
   }
 else
   echo "ERROR: Jira not configured"
-  echo "See: /founder-mode:help jira-setup"
+  echo "See: /fm:help jira-setup"
   exit 1
 fi
 ```
@@ -284,8 +284,8 @@ PROJ-789 [Task] Update documentation
          Sprint: Sprint 24
 
 Commands:
-  /founder-mode:fix-jira-ticket PROJ-123
-  /founder-mode:fix-issues PROJ-123 PROJ-456  (parallel)
+  /fm:fix-jira-ticket PROJ-123
+  /fm:fix-issues PROJ-123 PROJ-456  (parallel)
 ```
 
 ### Step 6: Handle Errors

--- a/prompts/phase-completion/004-03-fix-gh-issue.md
+++ b/prompts/phase-completion/004-03-fix-gh-issue.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement the end-to-end `/founder-mode:fix-gh-issue` workflow that goes from issue to PR.
+Implement the end-to-end `/fm:fix-gh-issue` workflow that goes from issue to PR.
 
 ## Prerequisites
 
@@ -350,7 +350,7 @@ To clean up: git worktree remove {worktree_path}
 When multiple issue numbers provided:
 
 ```
-/founder-mode:fix-gh-issue 123 456 789
+/fm:fix-gh-issue 123 456 789
 ```
 
 **Step 1: Dependency Analysis (before execution)**

--- a/prompts/phase-completion/005-01-parallel-execution.md
+++ b/prompts/phase-completion/005-01-parallel-execution.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement parallel issue execution using worktrees and the `/founder-mode:fix-issues` command.
+Implement parallel issue execution using worktrees and the `/fm:fix-issues` command.
 
 ## Prerequisites
 

--- a/prompts/phase-completion/005-02-sprint-workflow.md
+++ b/prompts/phase-completion/005-02-sprint-workflow.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Implement the `/founder-mode:run-sprint` command that automates sprint planning and execution.
+Implement the `/fm:run-sprint` command that automates sprint planning and execution.
 
 ## Prerequisites
 
@@ -251,7 +251,7 @@ Would execute:
 2. Spawn 3 parallel tasks (wave 1+2)
 3. Create 4 PRs
 
-To execute: /founder-mode:run-sprint
+To execute: /fm:run-sprint
 ```
 Exit without executing.
 
@@ -281,7 +281,7 @@ Use parallel execution infrastructure:
 
 ```
 Task(
-  prompt: "/founder-mode:fix-issues {issue_numbers}
+  prompt: "/fm:fix-issues {issue_numbers}
 
   Sprint: {sprint_name}
   Max parallel: {parallel_limit}
@@ -381,7 +381,7 @@ Failed Issues:
 Next Steps:
 1. Review PRs for merge
 2. Debug failed issues manually
-3. Run /founder-mode:run-sprint --filter "label:sprint-next"
+3. Run /fm:run-sprint --filter "label:sprint-next"
 ```
 
 ### Step 10: Update Sprint Tracking
@@ -430,7 +430,7 @@ Create .founder-mode/config.json with sprint settings:
   }
 }
 
-Or specify issues directly: /founder-mode:fix-issues 123 456 789
+Or specify issues directly: /fm:fix-issues 123 456 789
 ```
 
 **No issues found:**


### PR DESCRIPTION
## Summary
Fixes #2

- Rename all `/founder-mode:...` commands to `/fm:...`
- Update documentation and prompts
- Update agent references

## Changes
31 files modified across:
- `commands/` - All command files updated
- `agents/` - Agent references updated
- `prompts/` - All prompt files updated
- `.planning/` - Planning docs updated
- `CLAUDE.md` - Main documentation updated

## Verification
- [x] All /founder-mode: references replaced with /fm:
- [x] Documentation updated
- [x] No broken command references
- [x] Commit follows conventional format