### PR TITLE
fix: use git-common-dir for bare repo compatibility

### DIFF
--- a/commands/orchestrate.md
+++ b/commands/orchestrate.md
@@ -34,7 +34,12 @@ Locate orchestrator.py:
 ```bash
 PLUGIN_ROOT=$(jq -r '.plugins."founder-mode@local"[0].installPath // empty' ~/.claude/plugins/installed_plugins.json 2>/dev/null)
 if [ -z "$PLUGIN_ROOT" ]; then
+    # Works in normal repos and worktrees
     PLUGIN_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+fi
+if [ -z "$PLUGIN_ROOT" ]; then
+    # Fallback for bare repo parent setups
+    PLUGIN_ROOT=$(git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.bare$||; s|/\.git$||')
 fi
 ORCHESTRATOR="$PLUGIN_ROOT/scripts/orchestrator.py"
 ```

--- a/commands/run-prompt.md
+++ b/commands/run-prompt.md
@@ -396,7 +396,12 @@ PLUGIN_ROOT=$(jq -r '.plugins."founder-mode@local"[0].installPath // empty' ~/.c
 
 # Fallback: check if we're in the plugin directory
 if [ -z "$PLUGIN_ROOT" ]; then
+    # Works in normal repos and worktrees
     PLUGIN_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
+fi
+if [ -z "$PLUGIN_ROOT" ]; then
+    # Fallback for bare repo parent setups
+    PLUGIN_ROOT=$(git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.bare$||; s|/\.git$||')
 fi
 
 EXECUTOR="$PLUGIN_ROOT/scripts/executor.py"

--- a/prompts/006-git-worktree-integration.md
+++ b/prompts/006-git-worktree-integration.md
@@ -143,7 +143,7 @@ is_worktree() {
 
 # Get main repo path
 get_main_repo() {
-  git rev-parse --git-common-dir | sed 's|/\.git$||'
+  git rev-parse --git-common-dir | sed 's|/\.bare$||; s|/\.git$||'
 }
 
 # Get current worktree name
@@ -160,7 +160,7 @@ list_worktrees() {
 create_worktree() {
   local name="$1"
   local base_branch="${2:-HEAD}"
-  local common_dir=$(git rev-parse --git-common-dir | sed 's|/\.git$||')
+  local common_dir=$(git rev-parse --git-common-dir | sed 's|/\.bare$||; s|/\.git$||')
   local worktree_dir="${3:-$common_dir}"
 
   local path="${worktree_dir}/${name}"

--- a/references/worktree-utilities.md
+++ b/references/worktree-utilities.md
@@ -29,7 +29,7 @@ Get the common directory (shared git data location).
 
 ```bash
 get_common_dir() {
-  git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.git$||'
+  git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.bare$||; s|/\.git$||'
 }
 
 # Usage


### PR DESCRIPTION
## Summary
Fixes #10

Commands using `git rev-parse --show-toplevel` fail in bare repo parent directories (common in worktree setups). Added fallback to `--git-common-dir`.

## Changes
- Add fallback to `git rev-parse --git-common-dir` in `commands/orchestrate.md`
- Add fallback to `git rev-parse --git-common-dir` in `commands/run-prompt.md`
- Pattern strips both `/.bare` and `/.git` suffixes to get correct project root

## Pattern
```bash
PLUGIN_ROOT=$(jq -r '.plugins."founder-mode@local"[0].installPath // empty' ~/.claude/plugins/installed_plugins.json 2>/dev/null)
if [ -z "$PLUGIN_ROOT" ]; then
    PLUGIN_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
fi
if [ -z "$PLUGIN_ROOT" ]; then
    PLUGIN_ROOT=$(git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.bare$||; s|/\.git$||')
fi
```

## Verification
- [x] Both files updated with consistent pattern
- [x] Pattern matches reference in `worktree-utilities.md`