### PR TITLE
fix: add Agent to orchestrate.md allowed-tools

### DIFF
--- a/commands/orchestrate.md
+++ b/commands/orchestrate.md
@@ -7,6 +7,7 @@ allowed-tools:
   - Write
   - Bash
   - Glob
+  - Agent
   - Task
   - AskUserQuestion
   - TeamCreate


### PR DESCRIPTION
## Summary
Fixes #23

- Added `Agent` to the `allowed-tools` frontmatter list in `commands/orchestrate.md`
- Required for the agent-team execution path (step 6A) which calls `Agent()` to spawn teammates

## Changes
- `commands/orchestrate.md`: Added `- Agent` to allowed-tools list

## Verification
- [x] `Agent` is listed in allowed-tools frontmatter
- [x] Matches Agent tool usage in command body (lines 251, 255)