### PR TITLE
refactor: redesign fix-gh-issue and run-prompt composition

### DIFF
--- a/commands/fix-gh-issue.md
+++ b/commands/fix-gh-issue.md
@@ -9,228 +9,136 @@ allowed-tools:
   - Glob
   - Grep
   - Skill
+  - Task
   - AskUserQuestion
 ---
 
 # Fix GitHub Issue
 
-Compose first-principle commands to fix GitHub issues. Fetches issues, generates prompts, delegates execution to `/fm:run-prompt` or `/fm:orchestrate`, then creates PRs.
+Fix GitHub issues end-to-end: fetch issue, create worktree, generate prompt, execute via `/fm:run-prompt`, create PR.
 
 ## Arguments
 
 Parse from $ARGUMENTS:
 - Issue number(s): Single (123) or multiple (123 456 789)
-- `--no-worktree`: Skip worktree creation (default: creates worktree)
-- `--branch`: Custom branch name (default: uses github naming template)
+- `--no-worktree`: Skip worktree creation (work in current directory)
+- `--branch`: Custom branch name (default: `gh-{number}-{slug}`)
 - `--no-pr`: Skip PR creation, just commit
 - `--draft`: Create draft PR
 - `--model`: Model to use. Omit or use `?` to select interactively.
 
-## Process
+## Single Issue Flow
 
-### Step 1: Fetch Issue(s)
-
-For each issue number:
+### 1. Fetch Issue
 
 ```bash
-# Fetch issue details
-ISSUE=$(gh issue view $NUMBER --json title,body,labels,comments,url)
-
-# Parse fields
-TITLE=$(echo "$ISSUE" | jq -r '.title')
-BODY=$(echo "$ISSUE" | jq -r '.body')
-LABELS=$(echo "$ISSUE" | jq -r '.labels[].name' | tr '\n' ', ')
-URL=$(echo "$ISSUE" | jq -r '.url')
+gh issue view $NUMBER --json title,body,labels,comments,url
 ```
 
-Display issue summary:
+Display:
 ```
-Fetched Issue #{number}
-
-Title: {title}
+Issue #{number}: {title}
 Labels: {labels}
 URL: {url}
 
 {body preview, first 300 chars}
 ```
 
-Store parsed issues in memory for prompt generation.
+### 2. Create Worktree (unless --no-worktree)
 
-### Step 2: Dependency Analysis (multiple issues only)
+Create worktree before anything else. This is the working context for the fix.
 
-Skip this step for single issues.
-
-**Analyze the issues to determine dependencies:**
-
-Read each issue's title, body, and scope of work. Determine if any issue conceptually depends on another:
-- Does issue B's solution require changes that issue A would introduce?
-- Does issue B build upon functionality that issue A creates?
-- Is there a logical ordering where one must come before the other?
-
-<important>
-Dependency means conceptual relationship: one issue's solution requires or builds upon another's changes.
-
-Dependency does NOT mean issues happen to touch the same files. File overlap from parallel development is not a dependency. That's just a merge conflict to resolve later if it occurs.
-</important>
-
-**If no dependencies found:**
-
-Present analysis and proceed:
-
-```
-Dependency Analysis
-===================
-
-Issue #123: {title}
-Issue #456: {title}
-
-Analysis: These issues are independent. They address separate concerns
-and neither requires changes from the other.
-
-Execution Plan: Parallel worktrees, separate PRs.
-```
-
-**If dependencies found:**
-
-Present the analysis and proposed execution plan for user verification:
-
-```
-Dependency Analysis
-===================
-
-Issue #123: {title}
-Issue #456: {title}
-
-Analysis: Issue #456 depends on #123.
-Reason: {explain why - e.g., "#456 adds validation to the auth flow that #123 creates"}
-
-Proposed Execution Plan:
-
-Phase 1: Issue #123 (upstream)
-  → Worktree: gh-123-{slug}
-  → Creates the foundation needed by #456
-
-Phase 2: Issue #456 (downstream)
-  → Worktree: gh-456-{slug}
-  → Starts in parallel, merges #123 when ready
-  → Merge trigger: #123 has substantive commits + tests passing
-
-Separate PRs will be created for each issue.
-```
-
-Then ask user to verify:
-
-```
-AskUserQuestion(
-  questions: [{
-    question: "Does this dependency analysis look correct?",
-    header: "Verify",
-    options: [
-      { label: "Correct", description: "Proceed with this execution plan" },
-      { label: "Actually independent", description: "No dependency, run fully in parallel" },
-      { label: "Reverse dependency", description: "The other issue should be upstream" }
-    ]
-  }]
-)
-```
-
-Adjust execution plan based on user feedback.
-
-### Step 3: Generate Prompts
-
-For each issue, generate a prompt file. Do NOT call `/fm:create-prompt` (too heavyweight for issue context). Generate inline using this template:
-
-<issue_prompt_template>
-```markdown
-# Fix GitHub Issue #{number}
-
-<objective>
-Fix issue #{number}: {title}
-
-{issue body}
-</objective>
-
-<context>
-Repository: {repo from git remote}
-Issue URL: {url}
-Labels: {labels}
-Type: {bug|feature|enhancement inferred from labels}
-</context>
-
-<requirements>
-{Requirements parsed from issue body:}
-{For bugs: reproduction steps, expected vs actual behavior}
-{For features: what needs to be built}
-{For refactors: what needs to change}
-</requirements>
-
-<implementation>
-1. Search codebase for files related to issue
-2. Analyze affected components
-3. Implement the fix/feature
-4. Add or update tests to cover the change
-5. Verify tests pass
-6. Verify lint checks pass
-</implementation>
-
-<output>
-On completion, create a commit:
-- Message format: fix: {issue title}\n\nFixes #{number}\n\n- {change 1}\n- {change 2}
-- Stage only relevant files (not git add -A)
-</output>
-
-<verification>
-Before declaring complete:
-- [ ] Issue requirements addressed
-- [ ] Tests pass (run test command)
-- [ ] Lint passes (run lint command)
-- [ ] Changes committed with proper message
-</verification>
-```
-</issue_prompt_template>
-
-Save prompts to `.founder-mode/prompts/gh-issues/`:
+Read `worktree_dir` from founder_mode_config (default: `./`).
 
 ```bash
-mkdir -p .founder-mode/prompts/gh-issues
+COMMON_DIR=$(git rev-parse --git-common-dir | sed 's|/\.git$||; s|/\.bare$||')
 
 # Generate slug from title
 SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g' | \
   tr ' ' '\n' | grep -vE '^(a|an|the|in|on|at|to|for|of)$' | head -5 | \
   tr '\n' '-' | sed 's/--*/-/g' | sed 's/-$//' | cut -c1-30)
 
-PROMPT_FILE=".founder-mode/prompts/gh-issues/gh-${NUMBER}-${SLUG}.md"
+BRANCH="gh-${NUMBER}-${SLUG}"
+
+case "$WORKTREE_DIR_CONFIG" in
+  /*|~*) WORKTREE_BASE="${WORKTREE_DIR_CONFIG/#\~/$HOME}" ;;
+  *)     WORKTREE_BASE="$COMMON_DIR/$WORKTREE_DIR_CONFIG" ;;
+esac
+
+WORKTREE_PATH="$WORKTREE_BASE/$BRANCH"
+
+git worktree add "$WORKTREE_PATH" -b "$BRANCH" main
 ```
 
-Write the generated prompt content to `$PROMPT_FILE`.
-
-Report generation:
+Report:
 ```
-Generated Prompts
-=================
-
-{For each issue:}
-- gh-{number}-{slug}.md → Issue #{number}: {title (truncated to 50 chars)}
-
-Saved to: .founder-mode/prompts/gh-issues/
+Created worktree: {WORKTREE_PATH}
+Branch: {BRANCH}
 ```
 
-### Step 4: Model Selection (MANDATORY)
+### 3. Generate Prompt
+
+Generate a prompt file for the issue. Save to the main repo (not the worktree) so prompts survive worktree cleanup.
+
+```bash
+PROMPT_DIR="$COMMON_DIR/main/.founder-mode/prompts/gh-issues"
+mkdir -p "$PROMPT_DIR"
+PROMPT_FILE="$PROMPT_DIR/gh-${NUMBER}-${SLUG}.md"
+```
+
+Write using this template:
+
+```markdown
+# Fix GitHub Issue #{number}
+
+<objective>
+Fix issue #{number}: {title}
+
+{full issue body}
+</objective>
+
+<context>
+Repository: {repo from git remote}
+Issue URL: {url}
+Labels: {labels}
+</context>
+
+<requirements>
+{Requirements parsed from issue body}
+</requirements>
+
+<implementation>
+1. Search codebase for files related to issue
+2. Analyze affected components
+3. Implement the fix/feature
+4. Verify changes work correctly
+</implementation>
+
+<output>
+On completion, create a commit:
+- Message: {type}: {description}\n\nFixes #{number}\n\n- {change 1}\n- {change 2}
+- Stage only relevant files
+</output>
+```
+
+Report:
+```
+Generated prompt: {PROMPT_FILE}
+```
+
+### 4. Model Selection
 
 <critical>
-ALWAYS ask the user to select a model before execution. This step is MANDATORY.
-The only exception is when `--model` is explicitly provided in the arguments.
+ALWAYS ask unless `--model` is explicitly provided.
 </critical>
-
-If no `--model` specified (or `--model ?`):
 
 ```
 AskUserQuestion(
   questions: [{
-    question: "Which model should execute these prompts?",
+    question: "Which model should execute this prompt?",
     header: "Model",
     options: [
-      { label: "claude", description: "Claude in current session (Recommended)" },
+      { label: "claude", description: "Claude in current session" },
       { label: "codex", description: "OpenAI gpt-5.2-codex via codex CLI" },
       { label: "gemini", description: "Gemini 3 Flash via gemini CLI" },
       { label: "claude-zai", description: "Claude CLI with Z.AI backend" }
@@ -239,317 +147,177 @@ AskUserQuestion(
 )
 ```
 
-Wait for user selection before proceeding.
+### 5. Execute
 
-### Step 5: Execute via Orchestration
-
-Route based on issue count:
-
-<single_issue>
-**Single issue → run-prompt**
-
-Invoke run-prompt skill with generated prompt:
+Delegate to run-prompt. Pass the absolute prompt path, selected model, and worktree path as cwd. Do NOT pass `--worktree` (worktree already created in step 2).
 
 ```
 Skill(
   skill: "founder-mode:run-prompt",
-  args: "{prompt_file} --model {selected_model} {--worktree unless --no-worktree}"
+  args: "{PROMPT_FILE} --model {model} --cwd {WORKTREE_PATH}"
 )
 ```
 
-The run-prompt command handles:
-- Worktree creation (with proper naming from config)
-- Claude execution (via Task subagent) or non-Claude (via executor.py)
-- Result collection (COMPLETION.md or executor output)
+If `--no-worktree` was set, omit `--cwd` (run-prompt uses repo root).
 
-Wait for completion and collect result.
-</single_issue>
+### 6. Create PR (unless --no-pr)
 
-<multiple_issues>
-**Multiple issues → Always separate worktrees**
-
-<critical>
-Each issue ALWAYS gets its own worktree and its own PR by default.
-Never combine issues into a single worktree or PR without explicit user confirmation.
-</critical>
-
-Build comma-separated prompt list and invoke orchestrate:
+After execution completes, check for changes in the worktree:
 
 ```bash
-PROMPT_LIST=$(ls .founder-mode/prompts/gh-issues/gh-*.md | tr '\n' ',' | sed 's/,$//')
+cd "$WORKTREE_PATH"
+
+# Verify there are commits
+COMMITS=$(git log --oneline main..HEAD | wc -l)
+if [ "$COMMITS" -eq 0 ]; then
+    echo "No commits found. Skipping PR creation."
+    # report and exit
+fi
+
+git push -u origin "$BRANCH"
+
+gh pr create \
+  ${DRAFT:+--draft} \
+  --title "fix: {issue title}" \
+  --body "$(cat <<'PREOF'
+## Summary
+Fixes #{number}
+
+{brief description of changes}
+
+## Changes
+{output of git diff --stat main..HEAD}
+PREOF
+)"
+```
+
+### 7. Report
+
+```
+Issue #{number}: {title}
+  Status: {SUCCESS|FAILED}
+  Branch: {BRANCH}
+  PR: {pr_url}
+  Worktree: {WORKTREE_PATH}
+
+Clean up when done:
+  git worktree remove {WORKTREE_PATH}
+```
+
+---
+
+## Multiple Issue Flow
+
+### 1. Fetch Issues
+
+Fetch all issues:
+```bash
+for NUMBER in $ISSUE_NUMBERS; do
+  gh issue view $NUMBER --json title,body,labels,comments,url
+done
+```
+
+Display summary of each issue.
+
+### 2. Dependency Analysis
+
+Analyze the issues to determine if any depend on each other.
+
+<important>
+Dependency means one issue's solution requires or builds upon another's changes.
+File overlap from parallel development is NOT a dependency.
+</important>
+
+If dependencies found, present the analysis and ask user to verify:
+
+```
+AskUserQuestion(
+  questions: [{
+    question: "Does this dependency analysis look correct?",
+    header: "Verify",
+    options: [
+      { label: "Correct", description: "Proceed with this plan" },
+      { label: "Actually independent", description: "No dependency, run in parallel" },
+      { label: "Reverse dependency", description: "Swap the dependency direction" }
+    ]
+  }]
+)
+```
+
+### 3. Generate Prompts
+
+Generate one prompt file per issue using the same template as single-issue step 3.
+
+### 4. Model Selection
+
+Same as single-issue step 4. One model selection applies to all issues.
+
+### 5. Execute
+
+<critical>
+Each issue ALWAYS gets its own worktree and its own PR.
+Never combine issues without explicit user confirmation.
+</critical>
+
+Delegate to orchestrate for parallel execution. Orchestrate handles worktree creation per prompt.
+
+```bash
+PROMPT_LIST=$(echo $PROMPT_FILES | tr ' ' ',')
 ```
 
 ```
 Skill(
   skill: "founder-mode:orchestrate",
-  args: "{prompt_list} --model {selected_model} {--worktree unless --no-worktree}"
+  args: "{PROMPT_LIST} --model {model} --worktree"
 )
 ```
 
-The orchestrate command handles:
-- One worktree per issue (always isolated)
-- Parallel execution for non-Claude models
-- Spawning `readonly-log-watcher` monitors for background executions
-- Progress reporting per wave
-- Result collection
+If `--no-worktree` was set, omit `--worktree`.
 
-**Monitoring happens automatically:**
-- Orchestrate spawns `readonly-log-watcher` agents for background non-Claude executions
-- Monitors report progress every 30 seconds
-- Stall detection at 10/20/30 minute thresholds
-- User sees wave completion reports
+### 6. Collect Results
 
-Wait for orchestration to complete and collect all results.
-
-**Dependent issues workflow:**
-
-<important>
-Dependencies are determined by analyzing the issues in Step 2, then verified by the user.
-
-A dependency means issues are conceptually related: one issue's solution requires or builds upon another's changes. File overlap from parallel development is NOT a dependency.
-</important>
-
-When analysis determines issues have dependencies (e.g., issue B requires changes from issue A):
-
-1. **Analysis verified:** Dependency analysis presented in Step 2, user verified the execution plan
-2. **Parallel start:** Both issues begin in separate worktrees simultaneously
-3. **Merge timing:** Monitor upstream issue (A) for merge-ready state:
-   - Core implementation committed (not just scaffolding)
-   - Tests passing for the implemented portion
-   - No uncommitted changes blocking the merge
-4. **Merge and continue:** When A reaches merge-ready state, merge into B's worktree and resume B's agent
-5. **Separate PRs:** Create PRs with dependency notes
-
-**Merge-ready detection:**
-
-The orchestrator monitors each issue's worktree for merge-ready signals:
+Check each worktree for commits:
 ```bash
-# Check if issue A has substantive commits beyond initial setup
-COMMITS=$(git -C "$WORKTREE_A" log --oneline main..HEAD | wc -l)
-TESTS_PASS=$(git -C "$WORKTREE_A" diff --quiet && run_tests_in_worktree "$WORKTREE_A")
-
-if [ "$COMMITS" -gt 0 ] && [ "$TESTS_PASS" = "true" ]; then
-  # A is merge-ready, trigger merge into B
-  git -C "$WORKTREE_B" merge gh-{A-number}-{slug}
-fi
+for WORKTREE in $WORKTREE_PATHS; do
+  COMMITS=$(git -C "$WORKTREE" log --oneline main..HEAD | wc -l)
+  CHANGES=$(git -C "$WORKTREE" diff --stat main..HEAD)
+done
 ```
 
-**Sub-agent coordination:**
+If any failed, offer retry or skip.
 
-For dependent issues with sub-agents:
-1. **Decompose prompts:** Split each issue into phases if needed (setup, core impl, integration)
-2. **Phase-based merging:** Merge after upstream completes a phase, not necessarily the entire issue
-3. **Agent restart:** After merge, the downstream agent may need to restart with updated context:
-   - Re-read affected files to see upstream changes
-   - Adjust implementation approach if upstream introduced different patterns
-   - Continue from where it left off, not from scratch
-4. **Conflict handling:** If merge conflicts occur, pause downstream agent and surface to user
+### 7. Create PRs (unless --no-pr)
 
-```bash
-# In issue B's worktree, after A reaches merge-ready:
-git merge gh-{A-number}-{slug}  # or git rebase
-# Continue with B's implementation
-```
+Create one PR per issue using the same logic as single-issue step 6.
 
-Note: Since worktrees share the same repository, local branches are directly accessible without fetching from origin.
-</multiple_issues>
-
-### Step 6: Collect Results
-
-After execution completes, collect results from each issue's worktree:
-
-```bash
-# For each issue
-WORKTREE_PATH=$(git worktree list | grep "gh-${NUMBER}" | awk '{print $1}')
-
-if [ -f "$WORKTREE_PATH/COMPLETION.md" ]; then
-    STATUS=$(grep "Status:" "$WORKTREE_PATH/COMPLETION.md" | sed 's/.*Status: //')
-    SUMMARY=$(grep -A 5 "## Summary" "$WORKTREE_PATH/COMPLETION.md" | tail -n +2)
-fi
-```
-
-Report results:
-```
-Execution Results
-=================
-
-{For each issue:}
-Issue #{number}: {STATUS}
-  Worktree: {worktree_path}
-  Branch: {branch_name}
-  {Summary snippet}
-
-Overall: {success_count}/{total_count} succeeded
-```
-
-If any failed, offer retry:
-```
-{N} issue(s) failed. Options:
-1. Retry failed issues
-2. Continue to PR creation for successful ones
-3. Abort
-```
-
-### Step 7: Create PRs (unless --no-pr)
-
-For each successful issue worktree:
-
-```bash
-cd "$WORKTREE_PATH"
-
-# Push branch
-git push -u origin "$BRANCH"
-
-# Create PR
-PR_FLAGS=""
-[ "$DRAFT" = true ] && PR_FLAGS="--draft"
-
-gh pr create $PR_FLAGS \
-  --title "Fix: {issue title}" \
-  --body "$(cat <<'EOF'
-## Summary
-Fixes #{number}
-
-{summary from COMPLETION.md}
-
-## Changes
-{files changed from git diff --stat}
-
-## Verification
-- [x] Tests pass
-- [x] Lint clean
-EOF
-)" \
-  --assignee @me
-```
-
-Capture PR URL for each issue.
-
-### Step 8: Report Completion
+### 8. Report
 
 ```
-GitHub Issues Fixed
-===================
+Issues Fixed
+============
 
 {For each issue:}
 Issue #{number}: {title}
   Status: {SUCCESS|FAILED}
   Branch: {branch}
   PR: {pr_url}
-  Worktree: {worktree_path}
 
-Summary:
-- Issues processed: {total}
-- PRs created: {pr_count}
-- Failed: {failed_count}
+Summary: {success_count}/{total} succeeded
 
-{If worktrees used:}
-Clean up worktrees when done:
-  git worktree remove {path1}
-  git worktree remove {path2}
+Clean up worktrees:
+  {for each: git worktree remove {path}}
 ```
 
 ## Worktree Management
 
-See `references/worktree-management.md` for full details.
+See `references/worktree-management.md` for details.
 
-Worktree naming uses the `github` template from config:
-- Default: `gh-{number}-{slug}`
-- Example: `gh-123-fix-login-redirect`
-
-Worktree location from `worktree_dir` config (default: `./` relative to git common dir).
+Naming uses the `github` template: `gh-{number}-{slug}`
+Location from `worktree_dir` config (default: `./` relative to git common dir).
 
 ## Error Handling
 
-**Issue not found:**
-```
-Issue #{number} not found.
-
-Check:
-- Issue number is correct
-- You have access to the repository
-- gh CLI is authenticated
-```
-
-**Prompt generation failed:**
-```
-Failed to generate prompt for issue #{number}.
-
-Error: {error}
-
-Try fetching the issue manually:
-  gh issue view {number}
-```
-
-**Execution failed:**
-```
-Execution failed for issue #{number}.
-
-Status: {error from result}
-Log: {log path if available}
-
-Options:
-1. Retry this issue
-2. Skip and continue
-3. Abort
-```
-
-**PR creation failed:**
-```
-PR creation failed for issue #{number}.
-
-Error: {error}
-
-Manual creation:
-  cd {worktree_path}
-  git push -u origin {branch}
-  gh pr create --title "Fix: {title}" --body "Fixes #{number}"
-```
-
-## Examples
-
-**Fix single issue:**
-```
-/fm:fix-gh-issue 123
-```
-→ Asks for model, generates prompt, runs via run-prompt, creates PR
-
-**Fix multiple issues (always separate worktrees):**
-```
-/fm:fix-gh-issue 123 456 789
-```
-→ Creates 3 separate worktrees, generates 3 prompts, runs via orchestrate, creates 3 separate PRs
-
-**Fix dependent issues:**
-```
-/fm:fix-gh-issue 100 101  # where 101 depends on 100
-```
-→ Creates separate worktrees, works in parallel, merges 100 into 101's worktree when ready, creates 2 PRs
-
-**Fix with specific model:**
-```
-/fm:fix-gh-issue 123 --model codex
-```
-→ Skips model selection, uses codex
-
-**Fix without worktree:**
-```
-/fm:fix-gh-issue 123 --no-worktree
-```
-→ Works in current directory instead of isolated worktree
-
-**Fix as draft PR:**
-```
-/fm:fix-gh-issue 123 --draft
-```
-→ Creates draft PR instead of ready-for-review
-
-## Success Criteria
-
-- [ ] Issue(s) fetched and parsed
-- [ ] Prompt(s) generated in .founder-mode/prompts/gh-issues/
-- [ ] User selected model (or provided via --model)
-- [ ] Execution delegated to run-prompt (single) or orchestrate (multiple)
-- [ ] Results collected from worktrees
-- [ ] PR(s) created with proper references
-- [ ] User shown completion summary with PR URLs
+- **Issue not found:** Check issue number, repo access, gh auth
+- **Prompt generation failed:** Try `gh issue view {number}` manually
+- **Execution failed:** Check log output, offer retry or skip
+- **PR creation failed:** Show manual `gh pr create` command

--- a/commands/run-prompt.md
+++ b/commands/run-prompt.md
@@ -19,111 +19,34 @@ Execute a prompt file. Default: runs immediately in Claude with no menus, no con
 
 | Argument | Type | Default | Description |
 |----------|------|---------|-------------|
-| `<prompt-file>` | positional | required | Path to prompt .md file |
-| `--model` | option | (prompt) | Model to use. Omit or use `?` to select interactively. |
+| `<prompt-file>` | positional | required | Path to prompt .md file (absolute or relative) |
+| `--model` | option | (interactive) | Model to use. Omit or use `?` to select interactively. |
 | `--background` | flag | false | Run in background |
 | `--worktree` | flag | false | Create isolated git worktree |
 | `--worktree-cleanup` | flag | false | Remove worktree after execution (with --worktree) |
-| `--cwd` | option | repo root | Working directory |
+| `--cwd` | option | repo root | Working directory for execution |
 | `--log` | option | auto | Log file path (non-Claude only) |
 | `--verbose` | flag | false | Show detailed execution metadata |
 | `--loop` | flag | false | Enable verification loop (non-Claude only) |
 | `--two-stage` | flag | false | Enable two-stage verification (requires --loop) |
 
-## Flags
-
-### --two-stage
-
-Enable two-stage verification (requires `--loop`):
-
-1. **Stage 1: Spec Compliance**
-   - Does output match requirements?
-   - Are all features implemented?
-   - Do tests pass?
-   - Marker: `SPEC_COMPLIANCE_VERIFIED`
-
-2. **Stage 2: Code Quality** (only runs if Stage 1 passes)
-   - Is code well-organized?
-   - Is error handling complete?
-   - Any obvious improvements?
-   - Marker: `QUALITY_VERIFIED`
-
-Use for complex prompts where both correctness and quality matter.
-
-Example:
-```bash
-/fm:run-prompt my-feature --model codex --loop --two-stage
-```
-
-Result JSON includes:
-```json
-{
-  "status": "success",
-  "two_stage": true,
-  "stages_completed": ["spec", "quality"]
-}
-```
-
-## Model Selection (REQUIRED)
+## Fast Path
 
 <critical>
-ALWAYS ask the user to select a model before execution. This step is MANDATORY and must NEVER be skipped, even if it seems obvious which model to use.
-
-The only exception is when `--model` is explicitly provided in the arguments.
+When `--model` is provided, skip Step 1 (model selection).
+When `--cwd` is provided, skip Step 2 (worktree creation).
+When both are provided, skip directly to Step 3 (Execution).
 </critical>
 
-When no `--model` is specified (or `--model ?` is used):
-
-1. Read prompt content
-2. **MUST** ask user to select a model using AskUserQuestion
-3. Wait for user selection
-4. Execute with chosen model
-5. Show result
-
-```
-/fm:run-prompt prompts/fix-bug.md
-```
-
-To skip the model selection prompt, specify a model explicitly:
-```
-/fm:run-prompt prompts/fix-bug.md --model claude
-```
+This is the common path when called by other commands (e.g., fix-gh-issue) that have already handled model selection and worktree setup.
 
 ## Execution Flow
 
-<mode_detection>
-Determine execution mode based on `--model`:
+### Step 1: Model Selection
 
-**Claude models** (default): `claude`
-- Execute via Task subagent
-- Prompt content injected directly into Task prompt
+If `--model` is provided, skip this step.
 
-**Non-Claude models**: `codex`, `codex-high`, `codex-xhigh`, `gemini`, `gemini-high`, `gemini-xhigh`, `zai`, `opencode`, `opencode-zai`, `opencode-codex`, `claude-zai`, `local`, etc.
-- Execute via executor.py script
-- Parse JSON result and report status
-</mode_detection>
-
-### Step 1: Parse Arguments
-
-```
-prompt_file = first positional argument (required)
-model = --model value or null (not specified)
-background = --background flag present
-worktree = --worktree flag present
-cwd = --cwd value or current repo root
-log = --log value or auto-generated
-```
-
-Validate prompt file exists:
-```bash
-test -f "$prompt_file" && echo "exists" || echo "missing"
-```
-
-### Step 2: Model Selection (MANDATORY unless --model provided)
-
-<critical>
-If `model` is null or `?`, you MUST use AskUserQuestion to ask the user which model to use. Do NOT proceed to execution without explicit user selection. Do NOT assume "claude" or any other default.
-</critical>
+If `--model` is omitted or set to `?`, ask the user:
 
 ```
 AskUserQuestion(
@@ -132,54 +55,34 @@ AskUserQuestion(
     header: "Model",
     options: [
       { label: "claude", description: "Claude in current session" },
-      { label: "claude-zai", description: "Claude CLI with Z.AI backend" },
       { label: "codex", description: "OpenAI gpt-5.2-codex via codex CLI" },
-      { label: "gemini", description: "Gemini 3 Flash via gemini CLI" }
+      { label: "gemini", description: "Gemini 3 Flash via gemini CLI" },
+      { label: "claude-zai", description: "Claude CLI with Z.AI backend" }
     ]
   }]
 )
 ```
 
-**Wait for user response before proceeding to Step 3.**
+Wait for user response before proceeding.
 
-### Step 3: Worktree Creation (if --worktree)
+### Step 2: Worktree Creation (only if --worktree)
 
-Create isolated git worktree for execution. This happens in the skill layer, not executor.
+Skip if `--worktree` is not set. If `--cwd` is provided without `--worktree`, use that directory as-is.
 
 See `references/worktree-management.md` for full details.
 
-**Step 3a: Detect Location**
-
 ```bash
-COMMON_DIR=$(git rev-parse --git-common-dir | sed 's|/\.git$||')
-CURRENT_DIR=$(pwd)
+COMMON_DIR=$(git rev-parse --git-common-dir | sed 's|/\.git$||; s|/\.bare$||')
 ```
-
-**Step 3b: Read Config**
 
 Read `worktree_dir` and `worktree_naming.prompt` from founder_mode_config.
-
-Defaults:
-- `worktree_dir: ./` (flat layout in common directory)
-- `worktree_naming.prompt: prompt-{number}-{slug}`
-
-**Step 3c: Generate Name**
+Defaults: `worktree_dir: ./`, naming: `prompt-{number}-{slug}`
 
 ```bash
-# Extract prompt number from filename (e.g., 001 from 001-setup.md)
 PROMPT_NUMBER=$(basename "$prompt_file" .md | grep -oE '^[0-9]+')
-
-# Generate slug from prompt title or filename
 PROMPT_SLUG=$(basename "$prompt_file" .md | sed 's/^[0-9]*-//')
-
-# Apply naming template
 WORKTREE_NAME="prompt-${PROMPT_NUMBER}-${PROMPT_SLUG}"
-```
 
-**Step 3d: Compute Path**
-
-```bash
-# Resolve worktree_dir relative to common directory
 case "$WORKTREE_DIR_CONFIG" in
   /*|~*) WORKTREE_BASE="${WORKTREE_DIR_CONFIG/#\~/$HOME}" ;;
   *)     WORKTREE_BASE="$COMMON_DIR/$WORKTREE_DIR_CONFIG" ;;
@@ -188,74 +91,39 @@ esac
 WORKTREE_PATH="$WORKTREE_BASE/$WORKTREE_NAME"
 ```
 
-**Step 3e: Check Location and Confirm**
+If currently in a worktree (cwd != common dir), confirm the path with the user.
 
-If `CURRENT_DIR != COMMON_DIR` (user is in a worktree), ask for confirmation:
-
-```
-AskUserQuestion(
-  questions: [{
-    question: "You're in worktree '{current_worktree}'. Create new worktree at {WORKTREE_PATH}?",
-    header: "Worktree Path",
-    options: [
-      { label: "Yes, create there", description: "New worktree at {path}" },
-      { label: "Change location", description: "Specify a different path" },
-      { label: "Cancel", description: "Don't create a worktree" }
-    ]
-  }]
-)
-```
-
-**Step 3f: Create Worktree**
+Create the worktree:
 
 ```bash
-# Create parent directory if needed
 mkdir -p "$(dirname "$WORKTREE_PATH")"
 
-# Check if branch exists
 if git branch --list "$WORKTREE_NAME" | grep -q .; then
     git worktree add "$WORKTREE_PATH" "$WORKTREE_NAME"
 else
     git worktree add "$WORKTREE_PATH" -b "$WORKTREE_NAME" main
 fi
-
-# Copy prompt as TASK.md
-cp "$prompt_file" "$WORKTREE_PATH/TASK.md"
 ```
 
-Update `cwd` to `$WORKTREE_PATH` for subsequent execution.
+Set `cwd` to `$WORKTREE_PATH` for execution.
 
-**Step 3g: Cleanup (if --worktree-cleanup)**
-
-If `--worktree-cleanup` flag was specified, remove worktree after execution:
-
+If `--worktree-cleanup` is set, remove the worktree after execution completes:
 ```bash
 git worktree remove "$WORKTREE_PATH"
-git worktree prune
 ```
 
-By default, worktrees are kept for review. Report location after execution:
+### Step 3: Execution
 
-```
-Worktree: {WORKTREE_PATH}
-Branch: {WORKTREE_NAME}
+Determine mode from `--model`:
 
-Clean up when done:
-  git worktree remove {WORKTREE_PATH}
-```
+- **Claude** (`claude`): Execute via Task subagent
+- **Non-Claude** (everything else): Execute via executor.py
 
-### Step 4a: Claude Execution
+#### Claude Execution
 
-Read prompt content and spawn Task subagent.
+Read prompt file content and spawn Task subagent.
 
-```
-1. Read prompt file content
-2. Build Task prompt with injected content
-3. Spawn Task subagent
-```
-
-<claude_foreground>
-**Default foreground execution (no flags):**
+**Foreground (default):**
 
 ```
 Task(
@@ -264,29 +132,15 @@ Task(
 {prompt_content}
 </task>
 
+<working_directory>{cwd}</working_directory>
+
 Execute completely. Summarize what was accomplished.
 """,
   subagent_type: "general-purpose"
 )
 ```
 
-Output for default case:
-```
-Running: {prompt_file}
-
-{Task result/summary}
-```
-
-If `--verbose` flag is set, also show:
-```
-Model: claude
-Working Directory: {cwd}
-Duration: {elapsed}
-```
-</claude_foreground>
-
-<claude_background>
-**Background execution (`--background`):**
+**Background (`--background`):**
 
 ```
 Task(
@@ -301,7 +155,6 @@ Task(
 When finished, write {cwd}/COMPLETION.md with:
 
 # Completion Status
-
 **Status:** SUCCESS | FAILED | PARTIAL
 **Finished:** {timestamp}
 
@@ -310,13 +163,6 @@ When finished, write {cwd}/COMPLETION.md with:
 
 ## Files Changed
 - path/to/file - description
-
-## Verification
-- [x] or [ ] Build passed
-- [x] or [ ] Tests passed
-
-## Issues (if any)
-[Problems encountered]
 </completion_protocol>
 
 Execute the task completely, then write COMPLETION.md.
@@ -326,91 +172,22 @@ Execute the task completely, then write COMPLETION.md.
 )
 ```
 
-Report to user:
+Report background task location:
 ```
 Background task started.
-
 Working directory: {cwd}
-
-Check status:
-  cat {cwd}/COMPLETION.md
-
-Watch progress:
-  watch -n 5 'test -f {cwd}/COMPLETION.md && cat {cwd}/COMPLETION.md || echo "Still running..."'
+Check status: cat {cwd}/COMPLETION.md
 ```
-</claude_background>
 
-<worktree_background>
-**Worktree + Background combination (`--worktree --background`):**
+#### Non-Claude Execution
 
-1. Create worktree first (sync operation)
-2. Spawn background task in worktree
-3. COMPLETION.md written to worktree directory
-4. After completion, changes are in isolated branch
-
-Report to user:
-```
-Background task started in worktree.
-
-Worktree: {worktree_path}
-Branch: {branch_name}
-
-Check status:
-  cat {worktree_path}/COMPLETION.md
-
-After completion:
-  cd {worktree_path}
-  git log --oneline -5
-```
-</worktree_background>
-
-<non_claude_background>
-**Non-Claude background execution:**
-
-For non-Claude models with `--background`, executor.py handles logging.
-
-Report to user:
-```
-Background task started.
-
-Model: {model}
-Log: {log_path}
-
-Watch progress:
-  tail -f {log_path}
-
-Check process:
-  ps -p {pid}
-```
-</non_claude_background>
-
-### Step 4b: Non-Claude Execution
-
-Call executor.py for non-Claude models.
-
-<executor_path>
-Locate executor.py from the plugin's install path:
+Locate executor.py:
 ```bash
-# Get plugin root from installed_plugins.json
-PLUGIN_ROOT=$(jq -r '.plugins."founder-mode@local"[0].installPath // empty' ~/.claude/plugins/installed_plugins.json 2>/dev/null)
-
-# Fallback: check if we're in the plugin directory
-if [ -z "$PLUGIN_ROOT" ]; then
-    # Works in normal repos and worktrees
-    PLUGIN_ROOT=$(git rev-parse --show-toplevel 2>/dev/null)
-fi
-if [ -z "$PLUGIN_ROOT" ]; then
-    # Fallback for bare repo parent setups
-    PLUGIN_ROOT=$(git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.bare$||; s|/\.git$||')
-fi
-
+PLUGIN_ROOT=$(git rev-parse --git-common-dir 2>/dev/null | sed 's|/\.bare$||; s|/\.git$||')
 EXECUTOR="$PLUGIN_ROOT/scripts/executor.py"
 ```
-</executor_path>
 
-<executor_call>
-Build and execute command:
-
+Run:
 ```bash
 python3 "$EXECUTOR" \
   --prompt "$prompt_file" \
@@ -418,155 +195,65 @@ python3 "$EXECUTOR" \
   --model "$model"
 ```
 
-If `--log` specified:
-```bash
-python3 "$EXECUTOR" \
-  --prompt "$prompt_file" \
-  --cwd "$cwd" \
-  --model "$model" 2>&1 | tee "$log"
-```
-</executor_call>
+Additional flags passed through: `--background`, `--loop`, `--two-stage`, `--log`.
 
-<parse_result>
-Parse JSON output from executor:
+Parse JSON result from executor and report status.
 
-```json
-{
-  "repo": "project-name",
-  "model": "codex",
-  "cli_display": "codex (gpt-5.2-codex)",
-  "prompts": [{
-    "file": "/path/to/prompt.md",
-    "title": "Prompt Title",
-    "execution": {
-      "status": "running",
-      "pid": 12345,
-      "log": "/path/to/log"
-    }
-  }]
-}
-```
+### Step 4: Report
 
-Extract and report:
-- `execution.status`: running, completed, error
-- `execution.pid`: process ID for background tasks
-- `execution.log`: log file path
-</parse_result>
-
-### Step 5: Report Status
-
-<output_format>
-Present execution status to user:
-
-**Foreground (completed)**:
+**Foreground:**
 ```
 Execution Complete
-
-Model: {model} ({cli_display})
-Prompt: {prompt_file}
-Working Directory: {cwd}
-
-{summary from Task or executor output}
-```
-
-**Background (started)**:
-```
-Background Execution Started
-
-Model: {model} ({cli_display})
-Prompt: {prompt_file}
-Working Directory: {cwd}
-PID: {pid}
-Log: {log_path}
-
-Monitor with:
-  tail -f {log_path}
-
-Check process:
-  ps -p {pid}
-```
-
-**Worktree mode**:
-```
-Execution Started in Worktree
-
 Model: {model}
 Prompt: {prompt_file}
+Working Directory: {cwd}
+{summary}
+```
+
+**Background:**
+```
+Background Execution Started
+Model: {model}
+Log: {log_path}
+Monitor: tail -f {log_path}
+```
+
+**Worktree (append to either):**
+```
 Worktree: {worktree_path}
 Branch: {branch_name}
-
-After completion:
-  cd {worktree_path}
-  git log --oneline -5
-  git diff main...HEAD --stat
+Clean up when done: git worktree remove {worktree_path}
 ```
-</output_format>
+
+## Verification Loop (--loop)
+
+For non-Claude models only. executor.py handles the loop internally.
+
+`--two-stage` adds two-pass verification:
+1. Spec compliance (marker: `SPEC_COMPLIANCE_VERIFIED`)
+2. Code quality (marker: `QUALITY_VERIFIED`)
 
 ## Model Reference
 
-| Model | Type | CLI | Description |
-|-------|------|-----|-------------|
-| `claude` | Task subagent | claude | Claude in current context |
-| `codex` | executor.py | codex | OpenAI Codex (gpt-5.2-codex) |
-| `codex-high` | executor.py | codex | Codex with high reasoning |
-| `codex-xhigh` | executor.py | codex | Codex with max reasoning |
-| `gemini` | executor.py | gemini | Gemini 3 Flash |
-| `gemini-high` | executor.py | gemini | Gemini 2.5 Pro |
-| `gemini-xhigh` | executor.py | gemini | Gemini 3 Pro |
-| `zai` | executor.py | zai | Z.AI GLM-4.7 |
-| `opencode` | executor.py | opencode | OpenCode with default model (zen) |
-| `opencode-zai` | executor.py | opencode | OpenCode with Z.AI GLM-4.7 |
-| `opencode-codex` | executor.py | opencode | OpenCode with gpt-5.2-codex |
-| `claude-zai` | executor.py | claude | Claude CLI with Z.AI backend |
-| `local` | executor.py | lmstudio | Local model via LMStudio |
+| Model | Type | CLI |
+|-------|------|-----|
+| `claude` | Task subagent | claude |
+| `codex` | executor.py | codex |
+| `codex-high` | executor.py | codex (high reasoning) |
+| `codex-xhigh` | executor.py | codex (max reasoning) |
+| `gemini` | executor.py | gemini |
+| `gemini-high` | executor.py | gemini (2.5 Pro) |
+| `gemini-xhigh` | executor.py | gemini (3 Pro) |
+| `zai` | executor.py | zai |
+| `opencode` | executor.py | opencode |
+| `opencode-zai` | executor.py | opencode (Z.AI) |
+| `opencode-codex` | executor.py | opencode (codex) |
+| `claude-zai` | executor.py | claude (Z.AI backend) |
+| `local` | executor.py | lmstudio |
 
 ## Error Handling
 
-<error_prompt_not_found>
-If prompt file doesn't exist:
-```
-Prompt not found: {prompt_file}
-
-Available prompts:
-```
-
-Then run `ls ./prompts/*.md` and show available files.
-</error_prompt_not_found>
-
-<error_task_failure>
-If Task subagent fails:
-```
-Task failed.
-
-Check prompt content and try again.
-Error: {error_message}
-```
-</error_task_failure>
-
-Other errors:
-- Worktree creation fails: Report git error, suggest checking branch status
-- Executor not found: Report path issue, check executor location
-- Model not recognized: List available models
-- Background task fails: Check log file for details
-
-## Examples
-
-**Run with Claude (default)**:
-```
-/fm:run-prompt prompts/001-setup.md
-```
-
-**Run with Codex**:
-```
-/fm:run-prompt prompts/001-setup.md --model codex
-```
-
-**Run in background with worktree**:
-```
-/fm:run-prompt prompts/001-setup.md --model codex --background --worktree
-```
-
-**Run with custom working directory**:
-```
-/fm:run-prompt prompts/001-setup.md --cwd /path/to/project
-```
+- **Prompt not found:** List available prompts in the prompts directory
+- **Task subagent fails:** Report error, suggest checking prompt content
+- **Executor not found:** Check plugin install path
+- **Model not recognized:** List supported models from the table above


### PR DESCRIPTION
## Summary

Fixes the six composition problems observed when running `/fm:fix-gh-issue #23` end-to-end. Cuts total instruction weight from 1127 to 582 lines.

## Problems fixed

- **Step numbering gap**: Single issues showed Step 1, Step 3 (skipping dependency analysis). Now split into two distinct flows with clean sequential numbering.
- **Prompt created in wrong location**: Worktree was created after prompt generation, requiring a copy. Now worktree is created first (step 2), prompt generated after (step 3).
- **Worktree ownership confusion**: fix-gh-issue needs `gh-{number}-{slug}` naming but run-prompt uses `prompt-{number}-{slug}`. Now fix-gh-issue creates the worktree and passes `--cwd` to run-prompt instead of `--worktree`.
- **Context bloat**: 1100+ lines loaded when fix-gh-issue delegates to run-prompt. Added fast-path: `--model` skips model selection, `--cwd` skips worktree creation, both together skips straight to execution.
- **TASK.md artifact**: Prompt was copied as TASK.md into worktree, never read by anything. Removed.
- **COMPLETION.md in foreground path**: Was referenced in result collection but only written by background tasks. Scoped to `--background` only, foreground uses direct git inspection.
- **Missing allowed-tools**: Added `Task` to fix-gh-issue (needed when run-prompt spawns Claude subagents).

## Test plan

- [ ] Run `/fm:fix-gh-issue` on a real issue, verify clean step numbering
- [ ] Verify worktree created before prompt generation
- [ ] Verify model selection asked once (not twice)
- [ ] Verify PR created successfully
- [ ] Run `/fm:run-prompt` standalone with `--worktree` to confirm standalone path works
- [ ] Run `/fm:run-prompt` with `--model` and `--cwd` to confirm fast-path skips to execution